### PR TITLE
Fix gitPython not auto-closing repository :fox_face: 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,10 +61,9 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Attempt dev install
+      - name: Setup tox
         run: |
-          pip install .[dev]
+          pip install tox tox-gh-actions
 
       - name: Run tests with tox
-        run: |
-          python -m tox
+        run: tox

--- a/assignment_submission_checker/assignment.py
+++ b/assignment_submission_checker/assignment.py
@@ -102,6 +102,9 @@ class Assignment:
                         if changed:
                             repo_clean_msg = f"You have untracked changes to the following files in your git repository: {changed}"
 
+                # Close repo before ending function session
+                repo.close()
+
         return repo_present, repo_clean, repo_present_msg, repo_clean_msg
 
     def extract_to_temp_dir(self) -> None:

--- a/assignment_submission_checker/assignment.py
+++ b/assignment_submission_checker/assignment.py
@@ -138,7 +138,8 @@ class Assignment:
         Remove (if it exists) the temporary directory.
         """
         if os.path.exists(self.tmp_dir) and os.path.isdir(self.tmp_dir):
-            shutil.rmtree(self.tmp_dir, onerror=on_readonly_error)
+            shutil.rmtree(self.tmp_dir)
+            # shutil.rmtree(self.tmp_dir, onerror=on_readonly_error)
 
         return
 

--- a/assignment_submission_checker/assignment.py
+++ b/assignment_submission_checker/assignment.py
@@ -138,7 +138,6 @@ class Assignment:
         Remove (if it exists) the temporary directory.
         """
         if os.path.exists(self.tmp_dir) and os.path.isdir(self.tmp_dir):
-            # shutil.rmtree(self.tmp_dir)
             shutil.rmtree(self.tmp_dir, onerror=on_readonly_error)
 
         return

--- a/assignment_submission_checker/assignment.py
+++ b/assignment_submission_checker/assignment.py
@@ -138,8 +138,8 @@ class Assignment:
         Remove (if it exists) the temporary directory.
         """
         if os.path.exists(self.tmp_dir) and os.path.isdir(self.tmp_dir):
-            shutil.rmtree(self.tmp_dir)
-            # shutil.rmtree(self.tmp_dir, onerror=on_readonly_error)
+            # shutil.rmtree(self.tmp_dir)
+            shutil.rmtree(self.tmp_dir, onerror=on_readonly_error)
 
         return
 

--- a/assignment_submission_checker/utils.py
+++ b/assignment_submission_checker/utils.py
@@ -14,10 +14,5 @@ def on_readonly_error(f: Callable[[Path], None], path: Path, exc_info) -> None:
 
     Usage : ``shutil.rmtree(path, onerror=on_readonly_error)``
     """
-    # Attempt multiple times to allow os time to close references
-    for _ in range(50):
-        try:
-            os.chmod(path, stat.S_IWRITE)
-            f(path)
-        except:
-            pass
+    os.chmod(path, stat.S_IWRITE)
+    f(path)

--- a/tests/assignment/_base_testclass.py
+++ b/tests/assignment/_base_testclass.py
@@ -6,6 +6,33 @@ import pytest
 from assignment_submission_checker.assignment import Assignment
 
 
+@pytest.fixture(scope="function")
+def placeholder_assignment(tool: Literal["tar", "zip"] = "tar") -> Assignment:
+    """
+    Standard template assignment that can be used for testing.
+
+    It assumes the following directory and file structure is needed for the assignment:
+
+    candidate_number/
+    - assignment/
+    - - .git/
+    - - code_file_1.py
+    - - code_file_2.py
+    - - data/
+    - - - data_file_1.dat
+    """
+    return Assignment(
+        "Test assignment object",
+        git_root=Path("assignment"),
+        archive_tool=tool,
+        expected_files=[
+            Path("assignment/code_file_1.py"),
+            Path("assignment/code_file_2.py"),
+            Path("assignment/data/data_file_1.dat"),
+        ],
+    )
+
+
 class BaseAssignmentTestingClass:
     """
     Base class that provides a framework for testing the Assignment class.
@@ -31,32 +58,6 @@ class BaseAssignmentTestingClass:
     provided, extract it, run the wrapped test, and then handle removal of the
     extracted files (regardless of test result).
     """
-
-    @pytest.fixture(scope="function")
-    def placeholder_assignment(self, tool: Literal["tar", "zip"] = "tar") -> Assignment:
-        """
-        Standard template assignment that can be used for testing.
-
-        It assumes the following directory and file structure is needed for the assignment:
-
-        candidate_number/
-        - assignment/
-        - - .git/
-        - - code_file_1.py
-        - - code_file_2.py
-        - - data/
-        - - - data_file_1.dat
-        """
-        return Assignment(
-            "Test assignment object",
-            git_root=Path("assignment"),
-            archive_tool=tool,
-            expected_files=[
-                Path("assignment/code_file_1.py"),
-                Path("assignment/code_file_2.py"),
-                Path("assignment/data/data_file_1.dat"),
-            ],
-        )
 
     @pytest.fixture(
         autouse=True, scope="function"

--- a/tests/assignment/_base_testclass.py
+++ b/tests/assignment/_base_testclass.py
@@ -59,7 +59,7 @@ class BaseAssignmentTestingClass:
         )
 
     @pytest.fixture(
-        autouse=True
+        autouse=True, scope="function"
     )  # Refactor this into a base class, along with the placeholder fixture above, then subclass?
     @pytest.mark.parametrize("tool", ["tar"])
     def extract_run_teardown(self, placeholder_assignment: Assignment, data_path: Path) -> None:

--- a/tests/assignment/_base_testclass.py
+++ b/tests/assignment/_base_testclass.py
@@ -32,7 +32,7 @@ class BaseAssignmentTestingClass:
     extracted files (regardless of test result).
     """
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture(scope="function")
     def placeholder_assignment(self, tool: Literal["tar", "zip"] = "tar") -> Assignment:
         """
         Standard template assignment that can be used for testing.

--- a/tests/assignment/_base_testclass.py
+++ b/tests/assignment/_base_testclass.py
@@ -6,33 +6,6 @@ import pytest
 from assignment_submission_checker.assignment import Assignment
 
 
-@pytest.fixture(scope="function")
-def placeholder_assignment(tool: Literal["tar", "zip"] = "tar") -> Assignment:
-    """
-    Standard template assignment that can be used for testing.
-
-    It assumes the following directory and file structure is needed for the assignment:
-
-    candidate_number/
-    - assignment/
-    - - .git/
-    - - code_file_1.py
-    - - code_file_2.py
-    - - data/
-    - - - data_file_1.dat
-    """
-    return Assignment(
-        "Test assignment object",
-        git_root=Path("assignment"),
-        archive_tool=tool,
-        expected_files=[
-            Path("assignment/code_file_1.py"),
-            Path("assignment/code_file_2.py"),
-            Path("assignment/data/data_file_1.dat"),
-        ],
-    )
-
-
 class BaseAssignmentTestingClass:
     """
     Base class that provides a framework for testing the Assignment class.
@@ -58,6 +31,32 @@ class BaseAssignmentTestingClass:
     provided, extract it, run the wrapped test, and then handle removal of the
     extracted files (regardless of test result).
     """
+
+    @pytest.fixture(scope="function")
+    def placeholder_assignment(self, tool: Literal["tar", "zip"] = "tar") -> Assignment:
+        """
+        Standard template assignment that can be used for testing.
+
+        It assumes the following directory and file structure is needed for the assignment:
+
+        candidate_number/
+        - assignment/
+        - - .git/
+        - - code_file_1.py
+        - - code_file_2.py
+        - - data/
+        - - - data_file_1.dat
+        """
+        return Assignment(
+            "Test assignment object",
+            git_root=Path("assignment"),
+            archive_tool=tool,
+            expected_files=[
+                Path("assignment/code_file_1.py"),
+                Path("assignment/code_file_2.py"),
+                Path("assignment/data/data_file_1.dat"),
+            ],
+        )
 
     @pytest.fixture(
         autouse=True, scope="function"

--- a/tests/assignment/test_file_finder.py
+++ b/tests/assignment/test_file_finder.py
@@ -6,7 +6,7 @@ import pytest
 from assignment_submission_checker.assignment import Assignment
 
 from .. import DATA_DIR
-from ._base_testclass import BaseAssignmentTestingClass, placeholder_assignment
+from ._base_testclass import BaseAssignmentTestingClass
 
 
 class TestFileFinder(BaseAssignmentTestingClass):

--- a/tests/assignment/test_file_finder.py
+++ b/tests/assignment/test_file_finder.py
@@ -6,7 +6,7 @@ import pytest
 from assignment_submission_checker.assignment import Assignment
 
 from .. import DATA_DIR
-from ._base_testclass import BaseAssignmentTestingClass
+from ._base_testclass import BaseAssignmentTestingClass, placeholder_assignment
 
 
 class TestFileFinder(BaseAssignmentTestingClass):

--- a/tests/assignment/test_git.py
+++ b/tests/assignment/test_git.py
@@ -24,8 +24,8 @@ class TestGitDetection(BaseAssignmentTestingClass):
                 True,
                 id="Correct repo setup",
             ),
-            pytest.param(DATA_DIR / "no_git_missing_files.tar.gz", False, False, id="No git"),
             pytest.param(DATA_DIR / "dirty_git_extra_files.tar.gz", True, False, id="Dirty HEAD"),
+            pytest.param(DATA_DIR / "no_git_missing_files.tar.gz", False, False, id="No git"),
         ],
     )
     def test_git_detection(

--- a/tests/assignment/test_git.py
+++ b/tests/assignment/test_git.py
@@ -6,7 +6,7 @@ import pytest
 from assignment_submission_checker.assignment import Assignment
 
 from .. import DATA_DIR
-from ._base_testclass import BaseAssignmentTestingClass
+from ._base_testclass import BaseAssignmentTestingClass, placeholder_assignment
 
 
 class TestGitDetection(BaseAssignmentTestingClass):

--- a/tests/assignment/test_git.py
+++ b/tests/assignment/test_git.py
@@ -6,7 +6,7 @@ import pytest
 from assignment_submission_checker.assignment import Assignment
 
 from .. import DATA_DIR
-from ._base_testclass import BaseAssignmentTestingClass, placeholder_assignment
+from ._base_testclass import BaseAssignmentTestingClass
 
 
 class TestGitDetection(BaseAssignmentTestingClass):


### PR DESCRIPTION
Removes the need for the "hacky" try-catch loop when attempting teardown during Windows tests.

Turns out that GitPython needs to be explicitly told to release it's hold on a repository, even once the repository goes out of scope. Not sure why Ubuntu and MacOS were happy to do this, and Windows was not, but here we are.